### PR TITLE
Add MRR Skip split and fix some splits not splitting when the battle was reset

### DIFF
--- a/FFXComponent.cs
+++ b/FFXComponent.cs
@@ -134,6 +134,7 @@ namespace LiveSplit.FFX
     public static string OLD_ROAD = "OldRoad";
     public static string MUSHROOM_ROCK_ROAD = "MushroomRockRoad";
     public static string SINSPAWN_GUI = "SinspawnGui";
+    public static string MRR_SKIP = "MrrSkip";
     public static string DJOSE_HIGHROAD = "DjoseHighroad";
     public static string MOONFLOW = "Moonflow";
     public static string EXTRACTOR = "Extractor";

--- a/FFXMemory.cs
+++ b/FFXMemory.cs
@@ -196,7 +196,7 @@ namespace LiveSplit.FFX
             && (_data.EncounterFormationID1.Current == 0)
             && (_data.EncounterFormationID2.Current == 1)
             && (_data.BattleState.Current == 522)
-            && (_data.BattleState.Old == 10)
+            && (_data.BattleState.Old == 10 || _data.BattleState.Old == 512)
           )
           {
             canSplit = true;
@@ -218,7 +218,7 @@ namespace LiveSplit.FFX
             && (_data.EncounterFormationID1.Current == 0)
             && (_data.EncounterFormationID2.Current == 1)
             && (_data.BattleState.Current == 522)
-            && (_data.BattleState.Old == 10)
+            && (_data.BattleState.Old == 10 || _data.BattleState.Old == 512)
           )
           {
             canSplit = true;
@@ -231,7 +231,7 @@ namespace LiveSplit.FFX
             && (_data.EncounterFormationID1.Current == 0)
             && (_data.EncounterFormationID2.Current == 2)
             && (_data.BattleState.Current == 522)
-            && (_data.BattleState.Old == 10)
+            && (_data.BattleState.Old == 10 || _data.BattleState.Old == 512)
           )
           {
             canSplit = true;

--- a/FFXMemory.cs
+++ b/FFXMemory.cs
@@ -19,6 +19,7 @@ namespace LiveSplit.FFX
         {0x4F, new Tuple<int, SplitPair>(0x3B,  new SplitPair {SplitName = FFXComponent.OLD_ROAD,             SplitFlag = false})},     // FROM 59 - Highroad - North End                   TO  79 - Mushroom Rock
         {0x4C, new Tuple<int, SplitPair>(0x5D,  new SplitPair {SplitName = FFXComponent.DJOSE_HIGHROAD,       SplitFlag = false})},     // FROM 93 - Djose Highroad                         TO  76 - Djose - Pilgrimage Road
         {0x69, new Tuple<int, SplitPair>(0x4B,  new SplitPair {SplitName = FFXComponent.MOONFLOW,             SplitFlag = false})},     // FROM 75 - Moonflow - South Bank Road             TO  105 - Moonflow - South Bank
+        {0x83, new Tuple<int, SplitPair>(0x4F,  new SplitPair {SplitName = FFXComponent.MRR_SKIP,             SplitFlag = false})},     // FROM 79 - Mushroom Rock                          TO  131 - Mushroom Rock - Aftermath
         {0x8C, new Tuple<int, SplitPair>(0x87,  new SplitPair {SplitName = FFXComponent.GUADOSALAM,           SplitFlag = false})},     // FROM 135 - Guadosalam                            TO  140 - Thunder Plains - South
         {0x6E, new Tuple<int, SplitPair>(0xA2,  new SplitPair {SplitName = FFXComponent.THUNDER_PLAINS,       SplitFlag = false})},     // FROM 162 - Thunder Plains - North                TO  110 - Macalania Woods - South
         {0xDB, new Tuple<int, SplitPair>(0x118, new SplitPair {SplitName = FFXComponent.HOME,                 SplitFlag = false})},     // FROM 280 - Home - Main Corridor                  TO  219 - Home - Environment Controls

--- a/FFXSettings.cs
+++ b/FFXSettings.cs
@@ -32,6 +32,7 @@ namespace LiveSplit.FFX
       listView.Items.Add(FFXComponent.MIIHEN_HIGHROAD);
       listView.Items.Add(FFXComponent.OLD_ROAD);
       listView.Items.Add(FFXComponent.MUSHROOM_ROCK_ROAD);
+      listView.Items.Add(FFXComponent.MRR_SKIP);
       listView.Items.Add(FFXComponent.SINSPAWN_GUI);
       listView.Items.Add(FFXComponent.DJOSE_HIGHROAD);
       listView.Items.Add(FFXComponent.MOONFLOW);
@@ -59,7 +60,7 @@ namespace LiveSplit.FFX
       listView.Items.Add(FFXComponent.YU_YEVON);
 
       foreach (ListViewItem listViewItem in listView.Items)
-        listViewItem.Checked = true;
+        listViewItem.Checked = listViewItem.Text != FFXComponent.MRR_SKIP;
 
       HasChanged = true;
 


### PR DESCRIPTION
When autoloading into a fight, the game doesn't set the battle state to 10, it's still at 0 after the load.

Once the battle is over, the over bit 512 is set.

The game then fixed the missing flag for 10 in the frame after that.

So after a reset, the battle state changes from 0 -> 512 -> 522 instead of from 10 -> 522.

